### PR TITLE
Store settings names consistency

### DIFF
--- a/src/VirtoCommerce.BuilderIO.Web/Localizations/en.BuilderIo.json
+++ b/src/VirtoCommerce.BuilderIO.Web/Localizations/en.BuilderIo.json
@@ -2,12 +2,12 @@
   "settings": {
     "BuilderIO": {
       "Enable": {
-        "title": "Builder.io activation",
+        "title": "Builder.io",
         "description": "Enable/ disable Builder.io for the store"
       },
       "PublicApiKey": {
         "title": "Public API Key",
-        "description": "Builder Public API Key to integrate with Builder.io"
+        "description": "Enter Builder Public API Key to integrate with Builder.io"
       }
     }
   }


### PR DESCRIPTION

## Description
Store settings names consistency

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/PD-534
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.BuilderIO_3.806.0-pr-5-246f.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Text-only localization updates for store settings; no functional or behavioral code changes.
> 
> **Overview**
> Improves English UI copy for Builder.io store settings by renaming the enable setting title from *"Builder.io activation"* to *"Builder.io"* and clarifying the Public API key description to prompt the user to enter it.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3dd26bdb98bfa0d9be72a5f7925f7fef2dda2f09. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->