### PR TITLE
VCST-5069: Get page content with fallback

### DIFF
--- a/src/VirtoCommerce.BuilderIO.Core/Models/BuilderIOPage.cs
+++ b/src/VirtoCommerce.BuilderIO.Core/Models/BuilderIOPage.cs
@@ -41,7 +41,7 @@ public class BuilderIOPage
     public virtual PageDocument ToPageDocument()
     {
         var pageDocument = AbstractTypeFactory<PageDocument>.TryCreateInstance();
-        pageDocument.Content = GetDataProperty("blocksString");
+        pageDocument.Content = GetContent();
         pageDocument.CreatedBy = CreatedBy;
         pageDocument.CreatedDate = CreatedDate;
         pageDocument.Id = Id;
@@ -71,6 +71,18 @@ public class BuilderIOPage
     private string GetDataProperty(string propertyName)
     {
         return Data?.GetValueOrDefault(propertyName)?.ToString();
+    }
+
+    private string GetContent()
+    {
+        var blocksString = GetDataProperty("blocksString");
+        if (!string.IsNullOrWhiteSpace(blocksString))
+        {
+            return blocksString;
+        }
+
+        var blocks = Data?.GetValueOrDefault("blocks");
+        return blocks == null ? null : JsonConvert.SerializeObject(blocks);
     }
 
     private string GetQueryProperty(string propertyName, string operatorName = "is")


### PR DESCRIPTION
## Description

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5069
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.BuilderIO_3.1003.0-pr-11-ef88.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how page content is derived and serialized, which could affect downstream page rendering or stored content shape when `blocksString` is missing.
> 
> **Overview**
> `BuilderIOPage.ToPageDocument()` now populates `PageDocument.Content` via a new `GetContent()` helper instead of always reading `Data["blocksString"]`.
> 
> `GetContent()` returns `blocksString` when present, otherwise falls back to JSON-serializing `Data["blocks"]`, allowing pages to be imported even when the prebuilt string field is absent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef889cd0e44bc9b6cf26f5a127bf22a172d20bbd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->